### PR TITLE
Grad2-2876 WARN level log events

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -41,6 +41,15 @@ logging:
         boot:
           autoconfigure:
             logging: ${SPRING_BOOT_AUTOCONFIG_LOG_LEVEL}
+    jdk:
+      management:
+        agent: ERROR
+    sun:
+      management:
+        jmxremote: ERROR
+      rmi:
+        transport:
+          tcp: ERROR
 
 #Local properties
 server:

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -51,6 +51,15 @@ logging:
         boot:
           autoconfigure:
             logging: INFO
+    jdk:
+      management:
+        agent: ERROR
+    sun:
+      management:
+        jmxremote: ERROR
+      rmi:
+        transport:
+          tcp: ERROR
 
 #API Documentation
 springdoc:


### PR DESCRIPTION
Fixed WARN log events says "The server sockets created using the LocalRMIServerSocketFactory only accept connections from clients running on the host where the RMI remote objects have been exported...."