### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 18
       - uses: actions/cache@v4
@@ -33,7 +33,7 @@ jobs:
       - name: Run unit tests
         run: mvn -f pom.xml clean package
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.2.5
+        uses: aquasecurity/trivy-action@0.29.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -42,7 +42,7 @@ jobs:
           severity: 'CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
       - name: Cache SonarCloud packages

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,10 +33,10 @@
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <springdoc.version>2.0.2</springdoc.version>
         <junit>4.12</junit>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <resilience4j.version>2.0.2</resilience4j.version>
     </properties>
 
@@ -103,9 +103,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>21.3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -246,7 +246,7 @@
                 <plugin>
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                    <version>6.1.1.Final</version>
+                    <version>6.6.4.Final</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
@@ -336,7 +336,7 @@
                     <plugin>
                         <groupId>org.hibernate.orm.tooling</groupId>
                         <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                        <version>6.1.1.Final</version>
+                        <version>6.6.4.Final</version>
                         <executions>
                             <execution>
                                 <configuration>


### PR DESCRIPTION
Change Details:
- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.4.Final
- Bump org.mapstruct.version from 1.5.2.Final to 1.6.3 
- Bump actions/cache from 1 to 4  (Fixed exists on release branch)
- Bump actions/checkout from 2 to 4  (Fixed exists on release branch)
- Bump github/codeql-action from 2 to 3 
- Bump actions/setup-java from 1 to 4 
- Bump aquasecurity/trivy-action from 0.2.5 to 0.29.0 
- Bump log4j.version from 2.18.0 to 2.20.0
- Upgrade ojdbc8 to ojdbc11