### PR TITLE
GRAD2-3369 - uses string for key in mapDist of DistributionRequest so…

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/controller/DistributionController.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/controller/DistributionController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.undertow.util.BadRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +54,11 @@ public class DistributionController {
     public ResponseEntity<DistributionResponse> distributeCredentials(
             @PathVariable String runType, @RequestParam(required = false) Long batchId ,@RequestParam(required = false) String activityCode,
             @RequestParam(required = false) String transmissionType, @RequestBody DistributionRequest distributionRequest,
-            @RequestParam(required = false) String localDownload, @RequestHeader(name="Authorization") String accessToken) {
+            @RequestParam(required = false) String localDownload, @RequestHeader(name="Authorization") String accessToken,
+            @RequestParam(required = false, defaultValue = "false") boolean isPsi) throws BadRequestException {
+        if(!isPsi) {
+            validation.validateDistributionRequest(distributionRequest);
+        }
         if (isAsyncDistribution(runType, activityCode)) {
             // non-blocking IO - launching async process to distribute credentials
             gradDistributionService.asyncDistributeCredentials(runType,batchId,distributionRequest,activityCode,transmissionType,localDownload,accessToken);

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/controller/DistributionController.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/controller/DistributionController.java
@@ -25,6 +25,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import static ca.bc.gov.educ.api.distribution.process.DistributionProcessType.PSPR;
+
 @Slf4j
 @CrossOrigin
 @RestController
@@ -54,9 +56,8 @@ public class DistributionController {
     public ResponseEntity<DistributionResponse> distributeCredentials(
             @PathVariable String runType, @RequestParam(required = false) Long batchId ,@RequestParam(required = false) String activityCode,
             @RequestParam(required = false) String transmissionType, @RequestBody DistributionRequest distributionRequest,
-            @RequestParam(required = false) String localDownload, @RequestHeader(name="Authorization") String accessToken,
-            @RequestParam(required = false, defaultValue = "false") boolean isPsi) throws BadRequestException {
-        if(!isPsi) {
+            @RequestParam(required = false) String localDownload, @RequestHeader(name="Authorization") String accessToken) throws BadRequestException {
+        if(runType != null && !runType.equalsIgnoreCase(PSPR.name())) {
             validation.validateDistributionRequest(distributionRequest);
         }
         if (isAsyncDistribution(runType, activityCode)) {

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/model/dto/DistributionRequest.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/model/dto/DistributionRequest.java
@@ -6,14 +6,13 @@ import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @Data
 @Builder
 public class DistributionRequest {
     private String activityCode;
     private List<School> schools;
-    private Map<UUID, DistributionPrintRequest> mapDist;
+    private Map<String, DistributionPrintRequest> mapDist;
     private StudentSearchRequest studentSearchRequest;
 
     public StudentSearchRequest getStudentSearchRequest() {

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/model/dto/PsiCredentialDistribution.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/model/dto/PsiCredentialDistribution.java
@@ -9,7 +9,6 @@ public class PsiCredentialDistribution {
 
 	private String pen;
 	private String psiCode;
-	private UUID psiId;
 	private String psiYear;
 	private UUID studentID;
 }

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/process/CreateBlankCredentialProcess.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/process/CreateBlankCredentialProcess.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.educ.api.distribution.process;
 
+import ca.bc.gov.educ.api.distribution.constants.SchoolCategoryCodes;
 import ca.bc.gov.educ.api.distribution.model.dto.*;
 import ca.bc.gov.educ.api.distribution.model.dto.v2.School;
 import ca.bc.gov.educ.api.distribution.util.EducDistributionApiUtils;
@@ -32,13 +33,13 @@ public class CreateBlankCredentialProcess extends BaseProcess {
 		DistributionResponse response = new DistributionResponse();
 		ExceptionMessage exception = new ExceptionMessage();
 		DistributionRequest distributionRequest = processorData.getDistributionRequest();
-		Map<UUID, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
+		Map<String, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
 		StudentSearchRequest searchRequest = distributionRequest.getStudentSearchRequest();
 		Long batchId = processorData.getBatchId();
 		int numberOfPdfs = 0;
 		int counter=0;
-		for (Map.Entry<UUID, DistributionPrintRequest> entry : mapDist.entrySet()) {
-			UUID schoolId = entry.getKey();
+		for (Map.Entry<String, DistributionPrintRequest> entry : mapDist.entrySet()) {
+			UUID schoolId = UUID.fromString(entry.getKey());
 			counter++;
 			int currentSlipCount = 0;
 			DistributionPrintRequest distributionPrintRequest = entry.getValue();
@@ -117,7 +118,7 @@ public class CreateBlankCredentialProcess extends BaseProcess {
 								bcd.getCredentialTypeCode(), processorData.getBatchId());
 					}
 				}
-				mergeDocumentsPDFs(processorData,mincode,"02","/EDGRAD.T.","YED4",locations);
+				mergeDocumentsPDFs(processorData,mincode, SchoolCategoryCodes.INDEPEND.getCode(), "/EDGRAD.T.","YED4",locations);
 				numberOfPdfs++;
 				log.debug("*** Transcript Documents Merged");
 			} catch (IOException e) {
@@ -208,7 +209,7 @@ public class CreateBlankCredentialProcess extends BaseProcess {
 							bcd.getCredentialTypeCode(), failedToAdd, bcd.getCredentialTypeCode(), processorData.getBatchId());
 				}
 			}
-			mergeDocumentsPDFs(processorData, request.getMincode(),"02","/EDGRAD.C.",
+			mergeDocumentsPDFs(processorData, request.getMincode(),SchoolCategoryCodes.INDEPEND.getCode(),"/EDGRAD.C.",
 					request.getPaperType(), locations);
 		} catch (IOException e) {
 			log.debug(EXCEPTION,e.getMessage());

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/process/CreateReprintProcess.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/process/CreateReprintProcess.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.educ.api.distribution.process;
 
+import ca.bc.gov.educ.api.distribution.constants.SchoolCategoryCodes;
 import ca.bc.gov.educ.api.distribution.model.dto.*;
 import ca.bc.gov.educ.api.distribution.model.dto.v2.School;
 import lombok.Data;
@@ -30,13 +31,13 @@ public class CreateReprintProcess extends BaseProcess {
 		DistributionResponse response = new DistributionResponse();
 		ExceptionMessage exception = new ExceptionMessage();
 		DistributionRequest distributionRequest = processorData.getDistributionRequest();
-		Map<UUID, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
+		Map<String, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
 		StudentSearchRequest searchRequest = distributionRequest.getStudentSearchRequest();
 		Long batchId = processorData.getBatchId();
 		int numberOfPdfs = 0;
 		int counter=0;
-		for (Map.Entry<UUID, DistributionPrintRequest> entry : mapDist.entrySet()) {
-			UUID schoolId = entry.getKey();
+		for (Map.Entry<String, DistributionPrintRequest> entry : mapDist.entrySet()) {
+			UUID schoolId = UUID.fromString(entry.getKey());
 			counter++;
 			int currentSlipCount = 0;
 			DistributionPrintRequest distributionPrintRequest = entry.getValue();
@@ -169,7 +170,7 @@ public class CreateReprintProcess extends BaseProcess {
 							scd.getCredentialTypeCode(), failedToAdd, scd.getStudentID(), processorData.getBatchId());
 				}
 			}
-			mergeDocumentsPDFs(processorData, mincode,"02","/EDGRAD.C.", paperType, locations);
+			mergeDocumentsPDFs(processorData, mincode, SchoolCategoryCodes.INDEPEND.getCode(), "/EDGRAD.C.", paperType, locations);
 		} catch (IOException e) {
 			log.debug(EXCEPTION,e.getMessage());
 		}
@@ -184,7 +185,7 @@ public class CreateReprintProcess extends BaseProcess {
 			if(bytesSAR != null) {
 				locations.add(new ByteArrayInputStream(bytesSAR));
 			}
-			mergeDocumentsPDFs(processorData,mincode,"02","/EDGRAD.R.","324W",locations);
+			mergeDocumentsPDFs(processorData,mincode,SchoolCategoryCodes.INDEPEND.getCode(),"/EDGRAD.R.","324W",locations);
 		} catch (Exception e) {
 			log.debug(EXCEPTION,e.getMessage());
 		}

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/process/MergeProcess.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/process/MergeProcess.java
@@ -42,14 +42,14 @@ public class MergeProcess extends BaseProcess {
 		DistributionResponse response = new DistributionResponse();
 		ExceptionMessage exception = new ExceptionMessage();
 		DistributionRequest distributionRequest = processorData.getDistributionRequest();
-		Map<UUID, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
+		Map<String, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
 		StudentSearchRequest searchRequest = distributionRequest.getStudentSearchRequest();
 		Long batchId = processorData.getBatchId();
 		int numberOfPdfs = 0;
 		int counter = 0;
 		List<ca.bc.gov.educ.api.distribution.model.dto.School> schoolsForLabels = new ArrayList<>();
-		for (Map.Entry<UUID, DistributionPrintRequest> entry : mapDist.entrySet()) {
-			UUID schoolId = entry.getKey();
+		for (Map.Entry<String, DistributionPrintRequest> entry : mapDist.entrySet()) {
+			UUID schoolId = UUID.fromString(entry.getKey());
 			counter++;
 			int currentSlipCount = 0;
 			DistributionPrintRequest distributionPrintRequest = entry.getValue();

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/process/PostingSchoolReportProcess.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/process/PostingSchoolReportProcess.java
@@ -36,12 +36,12 @@ public class PostingSchoolReportProcess extends BaseProcess {
 		DistributionResponse response = new DistributionResponse();
 		ExceptionMessage exception = new ExceptionMessage();
 		DistributionRequest distributionRequest = processorData.getDistributionRequest();
-		Map<UUID, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
+		Map<String, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
 		StudentSearchRequest searchRequest = distributionRequest.getStudentSearchRequest();
 		int numberOfPdfs = 0;
 		int counter=0;
-		for (Map.Entry<UUID, DistributionPrintRequest> entry : mapDist.entrySet()) {
-			UUID schoolId = entry.getKey();
+		for (Map.Entry<String, DistributionPrintRequest> entry : mapDist.entrySet()) {
+			UUID schoolId = UUID.fromString(entry.getKey());
 			counter++;
 			DistributionPrintRequest distributionPrintRequest = entry.getValue();
 			ca.bc.gov.educ.api.distribution.model.dto.v2.School schoolDetails =

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/process/YearEndMergeProcess.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/process/YearEndMergeProcess.java
@@ -35,7 +35,7 @@ public class YearEndMergeProcess extends MergeProcess {
         ExceptionMessage exception = new ExceptionMessage();
         DistributionRequest distributionRequest = processorData.getDistributionRequest();
         Long batchId = processorData.getBatchId();
-        Map<UUID, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
+        Map<String, DistributionPrintRequest> mapDist = distributionRequest.getMapDist();
         StudentSearchRequest searchRequest = distributionRequest.getStudentSearchRequest();
         int numberOfPdfs = 0;
         int schoolCounter = 0;
@@ -45,8 +45,8 @@ public class YearEndMergeProcess extends MergeProcess {
         List<ca.bc.gov.educ.api.distribution.model.dto.School> schoolsForLabels = new ArrayList<>();
         List<District> districtsForLabels = new ArrayList<>();
         List<String> processedSchools = new ArrayList<>();
-        for (Map.Entry<UUID, DistributionPrintRequest> entry : mapDist.entrySet()) {
-            UUID schoolId = entry.getKey();
+        for (Map.Entry<String, DistributionPrintRequest> entry : mapDist.entrySet()) {
+            UUID schoolId = UUID.fromString(entry.getKey());
             DistributionPrintRequest distributionPrintRequest = entry.getValue();
             ca.bc.gov.educ.api.distribution.model.dto.v2.School schoolDetails =
                     getBaseSchoolDetails(distributionPrintRequest, searchRequest, schoolId, exception);

--- a/api/src/main/java/ca/bc/gov/educ/api/distribution/util/GradValidation.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/distribution/util/GradValidation.java
@@ -2,8 +2,11 @@ package ca.bc.gov.educ.api.distribution.util;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Consumer;
 
+import ca.bc.gov.educ.api.distribution.model.dto.DistributionRequest;
+import io.undertow.util.BadRequestException;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -104,4 +107,14 @@ public class GradValidation {
     	warningList.get().clear();
     	
     }
+
+		public void validateDistributionRequest(DistributionRequest distributionRequest) throws BadRequestException {
+			for (String key : distributionRequest.getMapDist().keySet()) {
+				try {
+					UUID.fromString(key);
+				} catch (IllegalArgumentException e) {
+					throw new BadRequestException(String.format("Invalid UUID in mapDist: %s", key), e);
+				}
+			}
+	}
 }

--- a/api/src/test/java/ca/bc/gov/educ/api/distribution/controller/DistributionControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/distribution/controller/DistributionControllerTest.java
@@ -10,6 +10,8 @@ import ca.bc.gov.educ.api.distribution.util.RestUtils;
 import io.undertow.util.BadRequestException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -41,9 +43,10 @@ class DistributionControllerTest {
 	
 	@Mock
 	SecurityContextHolder securityContextHolder;
-	
-	@Test
-	void testDistributeCredentials() throws BadRequestException {
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void testDistributeCredentials(boolean isPsi) throws BadRequestException {
 		String runType = "MER";
 		String activityCode = "USERDIST";
 		Long batchId= 9029L;
@@ -100,7 +103,7 @@ class DistributionControllerTest {
 
 		DistributionRequest distributionRequest = DistributionRequest.builder().mapDist(mapDist).build();
 		Mockito.when(gradDistributionService.distributeCredentials(runType,batchId,distributionRequest,activityCode, transmissionMode.toUpperCase(),null,"accessToken")).thenReturn(res);
-		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken", false);
+		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken", isPsi);
 		Mockito.verify(gradDistributionService).distributeCredentials(runType,batchId,distributionRequest,activityCode,transmissionMode.toUpperCase(),null,"accessToken");
 	}
 

--- a/api/src/test/java/ca/bc/gov/educ/api/distribution/controller/DistributionControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/distribution/controller/DistributionControllerTest.java
@@ -7,6 +7,7 @@ import ca.bc.gov.educ.api.distribution.service.PostingDistributionService;
 import ca.bc.gov.educ.api.distribution.util.GradValidation;
 import ca.bc.gov.educ.api.distribution.util.MessageHelper;
 import ca.bc.gov.educ.api.distribution.util.RestUtils;
+import io.undertow.util.BadRequestException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -42,11 +43,11 @@ class DistributionControllerTest {
 	SecurityContextHolder securityContextHolder;
 	
 	@Test
-	void testDistributeCredentials() {
+	void testDistributeCredentials() throws BadRequestException {
 		String runType = "MER";
 		String activityCode = "USERDIST";
 		Long batchId= 9029L;
-		Map<UUID, DistributionPrintRequest> mapDist= new HashMap<>();
+		Map<String, DistributionPrintRequest> mapDist= new HashMap<>();
 		String transmissionMode = "paper";
 		String mincode = "123123133";
 		UUID schoolId = UUID.randomUUID();
@@ -92,23 +93,23 @@ class DistributionControllerTest {
 		DistributionPrintRequest printRequest = new DistributionPrintRequest();
 		printRequest.setTranscriptPrintRequest(tPReq);
 		printRequest.setSchoolDistributionRequest(sdReq);
-		mapDist.put(schoolId, printRequest);
+		mapDist.put(schoolId.toString(), printRequest);
 
 		DistributionResponse res = new DistributionResponse();
 		res.setMergeProcessResponse("MERGED");
 
 		DistributionRequest distributionRequest = DistributionRequest.builder().mapDist(mapDist).build();
 		Mockito.when(gradDistributionService.distributeCredentials(runType,batchId,distributionRequest,activityCode, transmissionMode.toUpperCase(),null,"accessToken")).thenReturn(res);
-		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken");
+		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken", false);
 		Mockito.verify(gradDistributionService).distributeCredentials(runType,batchId,distributionRequest,activityCode,transmissionMode.toUpperCase(),null,"accessToken");
 	}
 
 	@Test
-	void testDistributeCredentialsAsynchronously() {
+	void testDistributeCredentialsAsynchronously() throws BadRequestException {
 		String runType = "MER";
 		String activityCode = "MONTHLYDIST";
 		Long batchId= 9029L;
-		Map<UUID, DistributionPrintRequest> mapDist= new HashMap<>();
+		Map<String, DistributionPrintRequest> mapDist= new HashMap<>();
 		String transmissionMode = "paper";
 		String mincode = "123123133";
 		UUID schoolId = UUID.randomUUID();
@@ -155,14 +156,14 @@ class DistributionControllerTest {
 		DistributionPrintRequest printRequest = new DistributionPrintRequest();
 		printRequest.setTranscriptPrintRequest(tPReq);
 		printRequest.setSchoolDistributionRequest(sdReq);
-		mapDist.put(schoolId,printRequest);
+		mapDist.put(schoolId.toString(),printRequest);
 
 		DistributionResponse res = new DistributionResponse();
 		res.setMergeProcessResponse("MERGED");
 
 		DistributionRequest distributionRequest = DistributionRequest.builder().mapDist(mapDist).build();
 		Mockito.doNothing().when(gradDistributionService).asyncDistributeCredentials(runType,batchId,distributionRequest,activityCode, transmissionMode.toUpperCase(),null,"accessToken");
-		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken");
+		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken", false);
 		Mockito.verify(gradDistributionService).asyncDistributeCredentials(runType,batchId,distributionRequest,activityCode,transmissionMode.toUpperCase(),null,"accessToken");
 	}
 

--- a/api/src/test/java/ca/bc/gov/educ/api/distribution/controller/DistributionControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/distribution/controller/DistributionControllerTest.java
@@ -45,10 +45,9 @@ class DistributionControllerTest {
 	SecurityContextHolder securityContextHolder;
 
 	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
-	void testDistributeCredentials(boolean isPsi) throws BadRequestException {
+	@ValueSource(strings = {"USERDIST", "PSPR"})
+	void testDistributeCredentials(String activityCode) throws BadRequestException {
 		String runType = "MER";
-		String activityCode = "USERDIST";
 		Long batchId= 9029L;
 		Map<String, DistributionPrintRequest> mapDist= new HashMap<>();
 		String transmissionMode = "paper";
@@ -103,7 +102,7 @@ class DistributionControllerTest {
 
 		DistributionRequest distributionRequest = DistributionRequest.builder().mapDist(mapDist).build();
 		Mockito.when(gradDistributionService.distributeCredentials(runType,batchId,distributionRequest,activityCode, transmissionMode.toUpperCase(),null,"accessToken")).thenReturn(res);
-		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken", isPsi);
+		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken");
 		Mockito.verify(gradDistributionService).distributeCredentials(runType,batchId,distributionRequest,activityCode,transmissionMode.toUpperCase(),null,"accessToken");
 	}
 
@@ -166,7 +165,7 @@ class DistributionControllerTest {
 
 		DistributionRequest distributionRequest = DistributionRequest.builder().mapDist(mapDist).build();
 		Mockito.doNothing().when(gradDistributionService).asyncDistributeCredentials(runType,batchId,distributionRequest,activityCode, transmissionMode.toUpperCase(),null,"accessToken");
-		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken", false);
+		distributionController.distributeCredentials(runType,batchId,activityCode,transmissionMode.toUpperCase(),distributionRequest,null,"accessToken");
 		Mockito.verify(gradDistributionService).asyncDistributeCredentials(runType,batchId,distributionRequest,activityCode,transmissionMode.toUpperCase(),null,"accessToken");
 	}
 

--- a/api/src/test/java/ca/bc/gov/educ/api/distribution/service/DistributionServiceTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/distribution/service/DistributionServiceTest.java
@@ -264,7 +264,7 @@ public class DistributionServiceTest {
 
     private synchronized DistributionResponse testDistributeSchoolReport(String runType, String reportType, String activityCode) {
         Long batchId = 9029L;
-        Map<UUID, DistributionPrintRequest> mapDist = new HashMap<>();
+        Map<String, DistributionPrintRequest> mapDist = new HashMap<>();
         String transmissionMode = "ftp";
         String accessToken = MOCK_TOKEN;
         String mincode = "123123133";
@@ -296,7 +296,7 @@ public class DistributionServiceTest {
 
         DistributionPrintRequest printRequest = new DistributionPrintRequest();
         printRequest.setSchoolReportPostRequest(tPReq);
-        mapDist.put(schoolId, printRequest);
+        mapDist.put(schoolId.toString(), printRequest);
 
         mockSchoolObject(schoolId);
 
@@ -608,7 +608,7 @@ public class DistributionServiceTest {
 
     private synchronized DistributionResponse testDistributeCredentials_transcript_blank(String runType, boolean schoolNull, String localDownload) {
         Long batchId = 9029L;
-        Map<UUID, DistributionPrintRequest> mapDist = new HashMap<>();
+        Map<String, DistributionPrintRequest> mapDist = new HashMap<>();
         String accessToken = MOCK_TOKEN;
         String transmissionMode = "paper";
         String mincode = "123123133";
@@ -639,7 +639,7 @@ public class DistributionServiceTest {
 
         DistributionPrintRequest printRequest = new DistributionPrintRequest();
         printRequest.setTranscriptPrintRequest(tPReq);
-        mapDist.put(schoolId, printRequest);
+        mapDist.put(schoolId.toString(), printRequest);
 
         mockSchoolObject(schoolId);
 
@@ -674,7 +674,7 @@ public class DistributionServiceTest {
 
     private synchronized DistributionResponse testDistributeCredentials_certificate_blank(String runType, String paperType) {
         Long batchId = 9029L;
-        Map<UUID, DistributionPrintRequest> mapDist = new HashMap<>();
+        Map<String, DistributionPrintRequest> mapDist = new HashMap<>();
         String transmissionMode = "ftp";
         String accessToken = MOCK_TOKEN;
         String mincode = "123123133";
@@ -707,7 +707,7 @@ public class DistributionServiceTest {
             printRequest.setYedbCertificatePrintRequest(cReq);
         if (paperType.equalsIgnoreCase("YEDR"))
             printRequest.setYedrCertificatePrintRequest(cReq);
-        mapDist.put(schoolId, printRequest);
+        mapDist.put(schoolId.toString(), printRequest);
 
         mockSchoolObject(schoolId);
 
@@ -741,7 +741,7 @@ public class DistributionServiceTest {
 
     private synchronized DistributionResponse testDistributeCredentials_transcript(String runType, String activityCode, boolean schoolNull, String localDownload, boolean isAsyncProcess) {
         Long batchId = 9029L;
-        Map<UUID, DistributionPrintRequest> mapDist = new HashMap<>();
+        Map<String, DistributionPrintRequest> mapDist = new HashMap<>();
         String accessToken = MOCK_TOKEN;
         String transmissionMode = "ftp";
         String mincode = "123123133";
@@ -794,7 +794,7 @@ public class DistributionServiceTest {
         DistributionPrintRequest printRequest = new DistributionPrintRequest();
         printRequest.setTranscriptPrintRequest(tPReq);
         printRequest.setSchoolDistributionRequest(sdReq);
-        mapDist.put(schoolId, printRequest);
+        mapDist.put(schoolId.toString(), printRequest);
 
         if (!schoolNull) {
             mockSchoolObject(schoolId);
@@ -952,7 +952,7 @@ public class DistributionServiceTest {
 
     private synchronized DistributionResponse testDistributeCredentials_certificate(String runType, String activityCode, String paperType, String properName, boolean noSchoolDis, boolean isAsyncProcess) {
         Long batchId = 9029L;
-        Map<UUID, DistributionPrintRequest> mapDist = new HashMap<>();
+        Map<String, DistributionPrintRequest> mapDist = new HashMap<>();
         String localDownload = "Y";
         String transmissionMode = "ftp";
         String accessToken = MOCK_TOKEN;
@@ -1032,7 +1032,7 @@ public class DistributionServiceTest {
             printRequest.setYedbCertificatePrintRequest(cReq);
         if (paperType.equalsIgnoreCase("YEDR"))
             printRequest.setYedrCertificatePrintRequest(cReq);
-        mapDist.put(schoolId, printRequest);
+        mapDist.put(schoolId.toString(), printRequest);
 
         mockSchoolObject(schoolId);
 
@@ -1212,7 +1212,7 @@ public class DistributionServiceTest {
 
     private synchronized DistributionResponse testDistributeCredentials_certificate_reprint(String runType, String activityCode, String paperType, boolean schoolNull) {
         Long batchId = 9029L;
-        Map<UUID, DistributionPrintRequest> mapDist = new HashMap<>();
+        Map<String, DistributionPrintRequest> mapDist = new HashMap<>();
         String localDownload = "Y";
         String accessToken = MOCK_TOKEN;
         String transmissionMode = "ftp";
@@ -1286,7 +1286,7 @@ public class DistributionServiceTest {
             printRequest.setYedbCertificatePrintRequest(cReq);
         if (paperType.equalsIgnoreCase("YEDR"))
             printRequest.setYedrCertificatePrintRequest(cReq);
-        mapDist.put(schoolId, printRequest);
+        mapDist.put(schoolId.toString(), printRequest);
 
         mockSchoolObject(schoolId);
 
@@ -1375,10 +1375,9 @@ public class DistributionServiceTest {
     private synchronized DistributionResponse testpsiDistributeCredential(String runType, String localDownload, String transmissionMode) {
         String activityCode = null;
         Long batchId = 9029L;
-        Map<UUID, DistributionPrintRequest> mapDist = new HashMap<>();
+        Map<String, DistributionPrintRequest> mapDist = new HashMap<>();
         String accessToken = MOCK_TOKEN;
         String psiCode = "001";
-        UUID psiId = UUID.randomUUID();
 
         Psi psiObj = new Psi();
         psiObj.setPsiCode("001");
@@ -1391,18 +1390,16 @@ public class DistributionServiceTest {
         scd.setPen("123213133");
         scd.setStudentID(UUID.randomUUID());
         scd.setPsiCode("001");
-        scd.setPsiId(psiId);
         scdList.add(scd);
 
         PsiCredentialPrintRequest cReq = new PsiCredentialPrintRequest();
         cReq.setBatchId(batchId);
         cReq.setCount(34);
         cReq.setPsiList(scdList);
-        cReq.setPsId(psiId.toString());
 
         DistributionPrintRequest printRequest = new DistributionPrintRequest();
         printRequest.setPsiCredentialPrintRequest(cReq);
-        mapDist.put(psiId, printRequest);
+        mapDist.put(psiCode, printRequest);
 
         //Grad2-1931 Setting properties for report data to test PSI FTP transmission mode.
         ReportData data = new ReportData();
@@ -1620,7 +1617,7 @@ public class DistributionServiceTest {
         when(this.responseMock.bodyToMono(String.class)).thenReturn(Mono.just("1"));
 
         when(this.webClient.get()).thenReturn(this.requestHeadersUriMock);
-        when(this.requestHeadersUriMock.uri(String.format(constants.getPsiByPsiCode(), psiId.toString()))).thenReturn(this.requestHeadersMock);
+        when(this.requestHeadersUriMock.uri(String.format(constants.getPsiByPsiCode(), psiCode))).thenReturn(this.requestHeadersMock);
         when(this.requestHeadersMock.headers(any(Consumer.class))).thenReturn(this.requestHeadersMock);
         when(this.requestHeadersMock.retrieve()).thenReturn(this.responseMock);
         when(this.responseMock.onStatus(any(), any())).thenReturn(this.responseMock);


### PR DESCRIPTION
… psi can call with psiCode and other distributions can use uuid.  Validate UUID when not psi run